### PR TITLE
add routing and detail page

### DIFF
--- a/class-components/package.json
+++ b/class-components/package.json
@@ -24,6 +24,7 @@
     "@types/react-dom": "^18.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.24.1",
     "vite-tsconfig-paths": "^4.3.2"
   },
   "devDependencies": {

--- a/class-components/src/App.tsx
+++ b/class-components/src/App.tsx
@@ -1,44 +1,20 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Animal, InputSearch, ResultSearch, Spinner } from './components/index.ts';
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import { Animals } from './pages/animals/Animals';
+import { NotFound } from './pages/notfound/NotFound';
 import './App.css';
-import api from './services/api.ts';
-import { useSearchQuery } from './hooks/useSearchQuery';
+import { AnimalDetails } from './components/details/AnimalDetails';
 
 const App: React.FC = () => {
-  const [animals, setAnimals] = useState<Animal[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(false);
-  const [searchQuery] = useSearchQuery('');
-
-  const getAnimals = useCallback(async (searchTerm: string) => {
-    setLoading(true);
-    try {
-      const res = await api.getAnimals(searchTerm);
-      setAnimals(res.animals);
-      setLoading(false);
-    } catch (err) {
-      console.error('Failed to fetch animals', err);
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    getAnimals(searchQuery);
-  }, [getAnimals, searchQuery]);
-
-  if (error) {
-    throw new Error('Test Error');
-  }
-
   return (
-    <>
-      <h1 className="header">Animals</h1>
-      <InputSearch onSearch={getAnimals} />
-      <button className="errorButton" onClick={() => setError(true)}>
-        Throw Test Error
-      </button>
-      {loading ? <Spinner /> : <ResultSearch animals={animals} />}
-    </>
+    <div className="App">
+      <Routes>
+        <Route path="/*" element={<Animals />}>
+          <Route path="details/:id" element={<AnimalDetails />} />
+        </Route>
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </div>
   );
 };
 

--- a/class-components/src/components/details/AnimalDetails.tsx
+++ b/class-components/src/components/details/AnimalDetails.tsx
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import api from '../../services/api';
+import { Spinner } from '../spinner/Spinner';
+import { Animal } from 'components';
+import { getAnimalType } from '../../utils/HelperString';
+
+export const AnimalDetails: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [animal, setAnimal] = useState<Animal | null>(null);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (id) {
+      fetchAnimalDetails(id);
+    }
+  }, [id]);
+
+  const fetchAnimalDetails = async (animalId: string) => {
+    setLoading(true);
+    try {
+      const res = await api.getAnimalDetails(animalId);
+      setAnimal(res.animal);
+    } catch (err) {
+      console.error('Failed to fetch animal details', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (!animal) {
+    return <p>No animal details available.</p>;
+  }
+
+  return (
+    <div onClick={(e) => e.stopPropagation()}>
+      <h2>{animal.name}</h2>
+      <p>Unique number: {animal.uid}</p>
+      <p>The Type is {getAnimalType(animal)}</p>
+      <button onClick={() => navigate('/')}>Close</button>
+    </div>
+  );
+};

--- a/class-components/src/components/mainsection/ResultSearch.module.scss
+++ b/class-components/src/components/mainsection/ResultSearch.module.scss
@@ -11,7 +11,7 @@
 
 .animal {
   width: 200px;
-  height: 150px;
+  height: 45px;
   border: 1px solid black;
   border-radius: 10px;
   margin: 10px 10px 0 0;

--- a/class-components/src/components/mainsection/ResultSearch.tsx
+++ b/class-components/src/components/mainsection/ResultSearch.tsx
@@ -4,33 +4,30 @@ import { Animal } from 'components';
 
 interface ResultSearchProps {
   animals: Animal[];
+  onItemClick: (id: string) => void;
 }
 
-export const ResultSearch: React.FC<ResultSearchProps> = ({ animals }) => {
-  const getAnimalType = (animal: Animal): string => {
-    if (animal.avian) return 'Avian';
-    if (animal.canine) return 'Canine';
-    if (animal.earthAnimal) return 'Earth Animal';
-    if (animal.earthInsect) return 'Earth Insect';
-    if (animal.feline) return 'Feline';
-    return 'not defined by default';
-  };
-
+export const ResultSearch: React.FC<ResultSearchProps> = ({ animals, onItemClick }) => {
   return (
     <>
       <section className={style.section}>
         {animals.length === 0 && (
           <div className={style.noResults}>No results. Try another name.</div>
         )}
-        {animals.map((animal) => (
-          <div key={animal.uid} className={style.animal}>
-            <p>{animal.name}</p>
-            <div className={style.description}>
-              <p>Unique number: {animal.uid}</p>
-              <p>The Type is {getAnimalType(animal)}</p>
+        <div>
+          {animals.map((animal) => (
+            <div
+              key={animal.uid}
+              className={style.animal}
+              onClick={(e) => {
+                e.stopPropagation();
+                onItemClick(animal.uid);
+              }}
+            >
+              <p>{animal.name}</p>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </section>
     </>
   );

--- a/class-components/src/main.tsx
+++ b/class-components/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { ErrorBoundary } from '../src/components/index';
+import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/class-components/src/pages/animals/Animals.module.scss
+++ b/class-components/src/pages/animals/Animals.module.scss
@@ -1,0 +1,61 @@
+#root {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+.logo {
+  height: 6em;
+  padding: 1.5em;
+  will-change: filter;
+  transition: filter 300ms;
+}
+.logo:hover {
+  filter: drop-shadow(0 0 2em #646cffaa);
+}
+.logo.react:hover {
+  filter: drop-shadow(0 0 2em #61dafbaa);
+}
+
+@keyframes logo-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  a:nth-of-type(2) .logo {
+    animation: logo-spin infinite 20s linear;
+  }
+}
+
+.card {
+  padding: 2em;
+}
+
+.read_the_docs {
+  color: #888;
+}
+
+/* Animals.css */
+.container {
+  display: flex;
+}
+
+.left_section,
+.right_section {
+  flex: 1;
+  padding: 20px;
+}
+
+.right_section {
+  background-color: #f9f9f9;
+  border-left: 1px solid #ddd;
+  width: 300px;
+  height: 300px;
+  margin: 200px 20px 100px;
+}

--- a/class-components/src/pages/animals/Animals.tsx
+++ b/class-components/src/pages/animals/Animals.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, Outlet, useParams } from 'react-router-dom';
+import { Animal, InputSearch, ResultSearch, Spinner } from '../../components/index';
+import api from '../../services/api';
+import style from './Animals.module.scss';
+
+export const Animals: React.FC = () => {
+  const [animals, setAnimals] = useState<Animal[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+
+  useEffect(() => {
+    const previousSearch = localStorage.getItem('search');
+    previousSearch ? getAnimals(previousSearch) : getAnimals('');
+  }, []);
+
+  const getAnimals = async (searchTerm: string) => {
+    setLoading(true);
+    try {
+      const res = await api.getAnimals(searchTerm);
+      setAnimals(res.animals);
+    } catch (err) {
+      console.error('Failed to fetch animals', err);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAnimalClick = (animalId: string) => {
+    navigate(`/details/${animalId}`);
+  };
+
+  const handleCloseDetails = () => {
+    navigate('/');
+  };
+
+  if (error) {
+    throw new Error('Test Error');
+  }
+
+  return (
+    <>
+      <h1 className="header">Animals</h1>
+      <InputSearch onSearch={getAnimals} />
+      <button className="errorButton" onClick={() => setError(true)}>
+        Throw Test Error
+      </button>
+      <div className={style.container}>
+        <div className={style.left_section} onClick={handleCloseDetails}>
+          {loading ? (
+            <Spinner />
+          ) : (
+            <ResultSearch animals={animals} onItemClick={handleAnimalClick} />
+          )}
+        </div>
+        <div className={style.right_section} onClick={(e) => e.stopPropagation()}>
+          {id && <Outlet />}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/class-components/src/pages/notfound/NotFound.tsx
+++ b/class-components/src/pages/notfound/NotFound.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const NotFound: React.FC = () => {
+  return (
+    <div>
+      <h1>404 - Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  );
+};

--- a/class-components/src/services/api.ts
+++ b/class-components/src/services/api.ts
@@ -14,5 +14,19 @@ const api = {
       })
       .catch((err) => err);
   },
+  getAnimalDetails: async (animalID: string) => {
+    return await fetch(`https://stapi.co/api/v1/rest/animal?uid=${animalID}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    })
+      .then(async (res) => {
+        const data = await res.json();
+        return data;
+      })
+      .catch((err) => err);
+  },
 };
 export default api;

--- a/class-components/src/utils/HelperString.ts
+++ b/class-components/src/utils/HelperString.ts
@@ -1,3 +1,14 @@
+import { Animal } from 'components';
+
 export const trunc = (text: string): string => {
   return text.trim();
+};
+
+export const getAnimalType = (animal: Animal): string => {
+  if (animal.avian) return 'Avian';
+  if (animal.canine) return 'Canine';
+  if (animal.earthAnimal) return 'Earth Animal';
+  if (animal.earthInsect) return 'Earth Insect';
+  if (animal.feline) return 'Feline';
+  return 'not defined by default';
 };


### PR DESCRIPTION
- [x] Main page displays search results. On item click page should be split into 2 section:
- left section will continue to display search results;
- right section should display details using Router Outlet (show loading indicator while making an additional call for details, - - add control for closing the section, also section should be closed when user clicks on the left section)
reflect in the url that "Details" section has been opened for the selected item (e.g. /?frontpage=2&details=1).
